### PR TITLE
Fix: add the right group to CI codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 *           @windranger-io/windranger-core
 
 # GitHub Actions owners
-/.github/   @windranger-io/windranger-core
+/.github/   @windranger-io/windranger-devops


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
change CI codeowners group