### PR TITLE
docs: npm ci over npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Git clone, then from the project root execute
 To retrieve the project dependencies and before any further tasks will run correctly
 
 ```shell
-npm install
+npm ci
 ```
 
 #### Husky Git Commit Hooks


### PR DESCRIPTION
### Purpose for this PR
Since the `package-lock.json` is now in the repo, the setup instructions should have that used (via `npm ci`), rather then creating a new version with `npm install` (slightly quicker setup process too)

<!-- Have you included adequate testing for this change? -->
