### PR TITLE
feat: solidity static analyser silther

### DIFF
--- a/.github/workflows/main-push-pull.yml
+++ b/.github/workflows/main-push-pull.yml
@@ -113,7 +113,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Slither Static Analysis
-        uses: luisfontes19/slither-static-analysis-action@v0.3.4
+      - name: Set up node
+        uses: actions/setup-node@v2.5.0
         with:
-          slither-params: '--filter-paths "contracts/test|contracts/treasury|node_modules" --exclude solc-version'
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+
+      - name: Install Slither
+        run: pip3 install slither-analyzer
+
+      - name: Slither Static Analysis
+        run: slither . --filter-paths "node_modules" --exclude solc-version

--- a/.github/workflows/main-push-pull.yml
+++ b/.github/workflows/main-push-pull.yml
@@ -121,9 +121,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build application
-        run: npm run build
-
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'

--- a/.github/workflows/main-push-pull.yml
+++ b/.github/workflows/main-push-pull.yml
@@ -126,11 +126,11 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
-          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+          python-version: '3.x'
+          architecture: 'x64'
 
       - name: Install Slither
         run: pip3 install slither-analyzer
 
       - name: Slither Static Analysis
-        run: slither . --filter-paths "node_modules" --exclude solc-version
+        run: slither . --filter-paths "node_modules" --exclude solc-version,naming-convention

--- a/.github/workflows/main-push-pull.yml
+++ b/.github/workflows/main-push-pull.yml
@@ -130,4 +130,4 @@ jobs:
         run: pip3 install slither-analyzer
 
       - name: Slither Static Analysis
-        run: slither . --filter-paths "node_modules" --exclude solc-version,naming-convention
+        run: slither . --config-file slither.json

--- a/.github/workflows/main-push-pull.yml
+++ b/.github/workflows/main-push-pull.yml
@@ -95,3 +95,25 @@ jobs:
 
       - name: Lint
         run: npm run lint-sol
+
+
+  Solidity-Static-Analysis-Slither:
+    runs-on: ubuntu-latest
+    name: Solidity static analysis (Slither)
+    needs: Unit-Tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        name: Set up cache
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Slither Static Analysis
+        uses: luisfontes19/slither-static-analysis-action@v0.3.4
+        with:
+          slither-params: '--filter-paths "contracts/test|contracts/treasury|node_modules" --exclude solc-version'

--- a/contracts/test/Tub.sol
+++ b/contracts/test/Tub.sol
@@ -12,6 +12,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  */
 contract Tub is Ownable {
     string private _value;
+    string private _valueToo;
 
     event Store(string value);
 

--- a/contracts/test/Tub.sol
+++ b/contracts/test/Tub.sol
@@ -12,7 +12,6 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  */
 contract Tub is Ownable {
     string private _value;
-    string private _valueToo;
 
     event Store(string value);
 

--- a/contracts/test/Tub.sol
+++ b/contracts/test/Tub.sol
@@ -12,7 +12,6 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  */
 contract Tub is Ownable {
     string private _value;
-    string private _valueOoo;
 
     event Store(string value);
 

--- a/contracts/test/Tub.sol
+++ b/contracts/test/Tub.sol
@@ -12,6 +12,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  */
 contract Tub is Ownable {
     string private _value;
+    string private _valueOoo;
 
     event Store(string value);
 

--- a/docs/development_process.md
+++ b/docs/development_process.md
@@ -46,6 +46,10 @@ https://google.github.io/styleguide/tsguide.html
 Follow the Soldity docs guide.
 https://docs.soliditylang.org/en/v0.8.7/style-guide.html
 
+### Solidity static analysis
+
+- [Slither](slither.md)
+
 ---
 
 ## Open Communication

--- a/docs/slither.md
+++ b/docs/slither.md
@@ -1,0 +1,82 @@
+# Slither - Solidity static analyzer
+
+We use the Trail of Bits Solidity static analyzer [Slither](https://github.com/crytic/slither).
+
+## Usage
+
+Either setup and run in your local environment or in a Docker container.
+
+### Local Environment
+
+#### Install
+
+With Python 3 in your environment, install using the Python package manager `pip3`:
+
+```shell
+pip3 install slither-analyzer
+```
+
+#### Run
+
+When at the project root, to run and exclude `BitDao.sol`, anything containing the path `contracts\treasury` or `node_modules`:
+
+```shell
+slither . --filter-paths "BitDAO.sol|contracts/treasury|node_modules"
+```
+
+### Docker
+
+The Trail of Bits toolbox image contains a number of applications (including Slither).
+
+#### Install
+
+With Docker in your environment, install the image from DockerHub:
+
+```shell
+docker pull trailofbits/eth-security-toolbox
+```
+
+#### Run
+
+To start a new container with your local source mounted/accessible within the container:
+(replacing <ABSOLUTE_PATH_TO_WORKING_DIRECTORY> with the absolute path to the project working directory)
+
+```shell
+docker run -it --mount type=bind,source=<ABSOLUTE_PATH_TO_WORKING_DIRECTORY>,destination=/home/ethsec/test-me trailofbits/eth-security-toolbox
+```
+
+The container will automatically start and log you in, with the project code located in `test-me`.
+Navigate into the `test-me` directory and run the static analysis:
+
+```shell
+cd test-me
+slither . --filter-paths "BitDAO.sol|contracts/treasury|node_modules"
+```
+
+## Excluded Detectors
+
+### Solidity version too new
+
+[incorrect-versions-of-solidity](https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity) ensures a version of Solidity is used, where the set of bugs and exploits are known. Practically this mean using a previous minor version of Solidity.
+
+When the release cycle is likely to pass a new minor of Solidity, using the latest version in development is acceptable, as that becomes a valid version by the time the audit has passed.
+
+### Functions must be camel case
+
+[conformance-to-solidity-naming-conventions](https://github.com/crytic/slither/wiki/Detector-Documentation#conformance-to-solidity-naming-conventions) ensures functions conform to camel case.
+
+The convention from Open Zeppelin upgradable contracts includes adding a CapWord for the contract.
+
+e.g OwnableUpgradable
+
+```solidity
+    function __Ownable_init() internal initializer {
+```
+
+## Excluded Directories
+
+Files and directories may be excluded when they're libraries, or are still under active development.
+
+### Node Modules
+
+From the perspective of the repo, everything under `node_modules` is considered as a library.

--- a/docs/slither.md
+++ b/docs/slither.md
@@ -81,4 +81,5 @@ Files and directories may be excluded when they are libraries, or are still unde
 
 ### Node Modules
 
+“
 Everything under `node_modules` is considered as a library (outside of the control of the project).

--- a/docs/slither.md
+++ b/docs/slither.md
@@ -39,7 +39,7 @@ docker pull trailofbits/eth-security-toolbox
 #### Run
 
 To start a new container with your local source mounted/accessible within the container:
-(replacing <ABSOLUTE_PATH_TO_WORKING_DIRECTORY> with the absolute path to the project working directory)
+(replacing `<ABSOLUTE_PATH_TO_WORKING_DIRECTORY>` with the absolute path to the project working directory)
 
 ```shell
 docker run -it --mount type=bind,source=<ABSOLUTE_PATH_TO_WORKING_DIRECTORY>,destination=/home/ethsec/test-me trailofbits/eth-security-toolbox
@@ -57,15 +57,17 @@ cd test-me
 
 ### Solidity version too new
 
-[incorrect-versions-of-solidity](https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity) ensures a version of Solidity is used, where the set of bugs and exploits are known. Practically this mean using a previous minor version of Solidity.
+[incorrect-versions-of-solidity](https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity)
+ensures an old version of Solidity (a previous minor version) is used, as the set of bugs and exploits are known.
 
-When the release cycle is likely to pass a new minor of Solidity, using the latest version in development is acceptable, as that becomes a valid version by the time the audit has passed.
+When the release cycle is likely to span the release of a new minor of Solidity, using the latest version in development is acceptable (that version becomes a valid version by the time the audit has passed).
 
 ### Functions must be camel case
 
-[conformance-to-solidity-naming-conventions](https://github.com/crytic/slither/wiki/Detector-Documentation#conformance-to-solidity-naming-conventions) ensures functions conform to camel case.
+[conformance-to-solidity-naming-conventions](https://github.com/crytic/slither/wiki/Detector-Documentation#conformance-to-solidity-naming-conventions)
+ensures functions aer in camel case.
 
-The convention from Open Zeppelin upgradable contracts includes adding a CapWord for the contract.
+The convention from Open Zeppelin upgradable contracts includes adding a CapWord for the contract to the init function.
 
 e.g OwnableUpgradable
 
@@ -75,8 +77,8 @@ e.g OwnableUpgradable
 
 ## Excluded Directories
 
-Files and directories may be excluded when they're libraries, or are still under active development.
+Files and directories may be excluded when they are libraries, or are still under active development.
 
 ### Node Modules
 
-From the perspective of the repo, everything under `node_modules` is considered as a library.
+Everything under `node_modules` is considered as a library (outside of the control of the project).

--- a/docs/slither.md
+++ b/docs/slither.md
@@ -18,10 +18,10 @@ pip3 install slither-analyzer
 
 #### Run
 
-When at the project root, to run and exclude `BitDao.sol`, anything containing the path `contracts\treasury` or `node_modules`:
+When at the project root, to run using the project configuration:
 
 ```shell
-slither . --filter-paths "BitDAO.sol|contracts/treasury|node_modules"
+slither . --config-file slither.json
 ```
 
 ### Docker
@@ -50,7 +50,7 @@ Navigate into the `test-me` directory and run the static analysis:
 
 ```shell
 cd test-me
-slither . --filter-paths "BitDAO.sol|contracts/treasury|node_modules"
+--config-file slither.json
 ```
 
 ## Excluded Detectors

--- a/slither.json
+++ b/slither.json
@@ -1,0 +1,10 @@
+{
+  "detectors_to_exclude": "solc-version,naming-convention",
+  "exclude_informational": false,
+  "exclude_low": false,
+  "exclude_medium": false,
+  "exclude_high": false,
+  "disable_color": true,
+  "filter_paths": "node_modules",
+  "legacy_ast": false
+}

--- a/slither.json
+++ b/slither.json
@@ -4,7 +4,7 @@
   "exclude_low": false,
   "exclude_medium": false,
   "exclude_high": false,
-  "disable_color": true,
+  "disable_color": false,
   "filter_paths": "node_modules",
   "legacy_ast": false
 }


### PR DESCRIPTION
### Purpose for this PR
A team review for the adding the Solidity Static analyser Silther.

Any problem encountered by Silther (error, warning or informational) causes the CI task to fail. 

The `node_modules` is excluded to avoid analysing the OZ contracts, with the detector `solc-version` excluded as using Solidity `0.8.x` fails and `naming-convention` detector excluded as the OZ convention for upgradable initializers fail (using double underscore with  CapWords).

https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity
https://github.com/crytic/slither/wiki/Detector-Documentation#conformance-to-solidity-naming-conventions

As per usual, this PR remains open for a week, to accomodate discussion & improvements. Today the update to doco has been included 🙂