### PR TITLE
feat: Dependabot to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["config:base", "group:all", "schedule:monthly"],
+  "assigneesFromCodeOwners": true,
+  "assigneesSampleSize": 1,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["pin", "digest", "lockFileMaintenance"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
### Purpose for this PR
Renovate raises dependency updates in a single PR, rather than one per a change (Dependabot).
<!-- Have you included adequate testing for this change? -->
