### PR TITLE
fix: enabling naming-convention detector

### DIFF
--- a/slither.json
+++ b/slither.json
@@ -1,5 +1,5 @@
 {
-  "detectors_to_exclude": "solc-version,naming-convention",
+  "detectors_to_exclude": "solc-version",
   "exclude_informational": false,
   "exclude_low": false,
   "exclude_medium": false,


### PR DESCRIPTION
### Purpose for this PR
Approach going forward will be to add `//slither-disable-next-line dead-code naming-convention` above line that require it (should only upgradable OZ convention inits)
<!-- Have you included adequate testing for this change? -->
