### PR TITLE
fix: dropping PlantUML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,4 @@ npm test
 Setup and run instructions:
 
 - [Hardhat](./docs/tools/hardhat.md)
-- [PlantUML](./docs/tools/plantuml.md); UML diagram generation from code.
 - [Slither](./docs/tools/slither.md); Trail of Bits Solidity static analyzer.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "lint": "npm run lint-ts && npm run lint-sol",
     "lint-ts": "eslint . --ext .ts",
     "lint-sol": "solhint ./contracts/**/*.sol",
-    "plant": "npx node-plantuml ./docs/specs",
     "prepare": "husky install",
     "test": "mocha --timeout 10000 --exit --recursive --require ts-node/register \"test/**/*.test.ts\""
   },
@@ -52,7 +51,6 @@
     "husky": "8.0.1",
     "lint-staged": "13.0.3",
     "mocha": "10.0.0",
-    "node-plantuml": "windranger-io/node-plantuml#fcfc730",
     "prettier": "2.7.1",
     "prettier-plugin-solidity": "1.0.0-dev.23",
     "solhint": "3.3.7",


### PR DESCRIPTION
### Purpose for this PR
PlantUML is no longer actively being used at Windranger for creating diagrams.

PlantUML is downloaded from SourceForge and occasionally fails, breaking the CI.
<!-- Have you included adequate testing for this change? -->
