### PR TITLE
fix: create a PR instead of direct commit

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,7 +47,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+
       - name: Push version update (package.json)
-        run: git push
-        env:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: Updating package.json version to ${{ github.event.release.tag_name }}
+          commit-message: 'release: version update'
+
+


### PR DESCRIPTION
### Purpose for this PR
Code Owners meaning the push attempted by the GitHub workflow fails, as the commit is not approved by a code owner.
<!-- Have you included adequate testing for this change? -->
